### PR TITLE
fix for mxcheck when domain has MX but has not A record (via Net::DNS)

### DIFF
--- a/lib/Email/Valid.pm
+++ b/lib/Email/Valid.pm
@@ -146,7 +146,7 @@ sub _net_dns_query {
 
   my $packet = $Resolver->send($host, 'MX') or croak $Resolver->errorstring;
   if ($packet->header->ancount) {
-    my @mx_entries = grep { $_->{'type'} eq 'MX' } $packet->answer;
+    my @mx_entries = grep { $_->type eq 'MX' } $packet->answer;
     if(@mx_entries) {
         my $mx = ($mx_entries[0])->exchange;
         if ($mx eq '.' or $mx eq '') {


### PR DESCRIPTION
this bug was introduced in Email-Valid-1.193

to demonstrate install `Net::DNS` and try:

```
perl -MEmail::Valid -E "say Email::Valid->address( -address=>'test@asqtstdmn.auditsquare.com', -mxcheck=>1) ? 'yes' : 'no'"
```
