### PR TITLE
Fix for undef dns mx query

### DIFF
--- a/lib/Email/Valid.pm
+++ b/lib/Email/Valid.pm
@@ -150,6 +150,7 @@ sub _net_dns_query {
     foreach my $mx (@mx_entries) {
       my $mxhost = $mx->exchange;
       my $query  = $Resolver->search($mxhost);
+      next unless ($query);
       foreach my $a_rr ($query->answer) {
         return 1 unless $a_rr->type ne 'A';
       }


### PR DESCRIPTION
Added test for `undef` result to mx query

fixes issue #22 