### PR TITLE
allow constructor args without dashes

### DIFF
--- a/t/constructor-args.t
+++ b/t/constructor-args.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+
+use Email::Valid;
+
+eval {
+    Email::Valid->new( -mxcheck => 3, bad => 1 );
+};
+
+like $@, qr/argument 'bad' not recognized/, 'throws an error';
+
+subtest 'can pass args as hashref' => sub {
+    my $ev = Email::Valid->new({ mxcheck => 1, fudge => 2 });
+
+    is $ev->{mxcheck} => 1;
+    is $ev->{fudge}   => 2;
+};
+
+subtest 'can pass args without dashes' => sub {
+    my $ev = Email::Valid->new( mxcheck => 1, fudge => 2);
+
+    is $ev->{mxcheck} => 1;
+    is $ev->{fudge}   => 2;
+};


### PR DESCRIPTION
For #1

I tweaked the _arrange sub such that it's smart enough to recognize params passed with dashes, without dashes (via `new`) and via an explicit hashref.