### PR TITLE
In testing use Capture::Tiny

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,29 @@
+version: 1.0.{build}
+
+branches:
+  except:
+    - /travis/
+skip_tags: true
+
+cache:
+  - C:\strawberry -> appveyor.yml
+
+install:
+  - if not exist "C:\strawberry" cinst strawberryperl
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd C:\projects\%APPVEYOR_PROJECT_NAME%
+  - cpanm --installdeps .
+
+build_script:
+  - perl Makefile.PL
+  - gmake
+
+test_script:
+  - gmake test TEST_VERBOSE=1
+
+notifications:
+  - provider: Email
+    to:
+    - jkeenan@cpan.org
+    on_build_status_changed: true
+

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,7 +30,7 @@ WriteMakefile(
       'Scalar::Util'  => 0, # for blessed()
       ($need_net_dns ? ('Net::DNS' => 0) : ()),
       ((!$need_net_dns and $^O =~ /\AMSWin32|Cygwin\z/)
-        ? ('IO::CaptureOutput' => 0)
+        ? ('Capture::Tiny' => 0)
         : ()
       ),
     },

--- a/lib/Email/Valid.pm
+++ b/lib/Email/Valid.pm
@@ -194,10 +194,10 @@ sub _nslookup_query {
   # Check for an MX record
   if ($^O eq 'MSWin32' or $^O eq 'Cygwin') {
     # Oh no, we're on Windows!
-    require IO::CaptureOutput;
-    my $response = IO::CaptureOutput::capture_exec(
+    require Capture::Tiny;
+    my $response = Capture::Tiny::capture_stdout {
      $Nslookup_Path, '-query=mx', $host
-    );
+    };
     croak "unable to execute nslookup '$Nslookup_Path': exit $?" if $?;
     print STDERR $response if $Debug;
     $response =~ /$NSLOOKUP_PAT/io or return $self->details('mx');


### PR DESCRIPTION
To replace IO::CaptureOutput, deprecated by CPAN maintainer.

An .appveyor.yml configuration is added solely to facilitate developer's testing on Windows.  This can be deleted after merge.